### PR TITLE
Add PHPStan Level 5 static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 		],
 		"i18n:pot": "wp i18n make-pot . languages/fyeo.pot --slug=fyeo --domain=fyeo --exclude=node_modules,vendor,wordpress",
 		"i18n:po": "wp i18n update-po languages/fyeo.pot languages/",
-		"i18n:update": [ "@i18n:pot", "@i18n:po" ]
+		"i18n:update": [ "@i18n:pot", "@i18n:po" ],
+		"phpstan": "phpstan analyse --memory-limit=1G"
 
     },
     "minimum-stability": "stable",
@@ -37,7 +38,10 @@
         "phpunit/phpunit": "^9",
         "wp-coding-standards/wpcs": "^3.0",
         "yoast/phpunit-polyfills": "^2.0",
-        "wp-cli/wp-cli-bundle": "^2.12"
+        "wp-cli/wp-cli-bundle": "^2.12",
+        "phpstan/phpstan": "^2.1",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wordpress-stubs": "^6.9"
     },
     "autoload": {
         "psr-0": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method DOMNameSpaceNode\|DOMNode\:\:getAttribute\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Hametuha/ForYourEyesOnly/Parser.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - for-your-eyes-only.php
+        - app/
+        - src/


### PR DESCRIPTION
## Summary
- PHPStan Level 5 + WordPress extensions を追加
- 既存エラーは baseline に記録（新規コードのみ Level 5 準拠を要求）
- `composer phpstan` で実行可能

タロスカイ全プラグイン標準化の一環。

🤖 Generated with [Claude Code](https://claude.com/claude-code)