### PR TITLE
Add phpstan files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -24,6 +24,8 @@ multisite.xml
 multisite.xml.dist
 phpcs.xml
 phpcs.ruleset.xml
+phpstan.neon
+phpstan-baseline.neon
 wp-cli.local.yml
 yarn.lock
 tests


### PR DESCRIPTION
## Summary
- Add phpstan.neon and phpstan-baseline.neon to .distignore to exclude from WordPress.org deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)