### PR TITLE
Replace bin/build.sh with npm run package in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,11 @@ jobs:
         with:
           node-version-file: '.node-version'
 
-      - name: Build Plugin
-        run: bash bin/build.sh ${{ github.event.release.tag_name }}
+      - name: Install dependencies and build Assets
+        run: |
+          composer install --no-dev --prefer-dist
+          npm install
+          npm run package
 
       - name: Compile Translations
         run: composer i18n


### PR DESCRIPTION
## Summary
- Replace `bash bin/build.sh` with direct `npm run package` command
- Keep `composer i18n` step for translation compilation

## Test plan
- [ ] Verify deploy workflow runs correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)