### PR TITLE
Add WordPress Playground PR preview

### DIFF
--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -1,0 +1,15 @@
+name: Playground Preview - Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'playground') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'playground')
+    uses: tarosky/workflows/.github/workflows/playground-preview-build.yml@main

--- a/.github/workflows/playground-preview-publish.yml
+++ b/.github/workflows/playground-preview-publish.yml
@@ -1,0 +1,18 @@
+name: Playground Preview - Publish
+
+on:
+  workflow_run:
+    workflows: ["Playground Preview - Build"]
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  publish:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    uses: tarosky/workflows/.github/workflows/playground-preview-publish.yml@main


### PR DESCRIPTION
## Summary

- PRに `playground` ラベルを付けるとWordPress Playgroundプレビューが生成される仕組みを追加
- `playground-preview-build.yml`: ラベル付与時にプラグインZIPをビルド・アップロード
- `playground-preview-publish.yml`: ビルド完了後にPRコメントでプレビューリンクを投稿
- `tarosky/workflows` の共有ワークフローを呼び出し

## Usage

1. PRに `playground` ラベルを追加
2. ビルドが自動実行
3. PRコメントにPlaygroundプレビューリンクが投稿される

🤖 Generated with [Claude Code](https://claude.com/claude-code)