### PR TITLE
Fix dynamic attribute not applying filter default value

### DIFF
--- a/app/Hametuha/ForYourEyesOnly/Parser.php
+++ b/app/Hametuha/ForYourEyesOnly/Parser.php
@@ -76,6 +76,10 @@ class Parser extends Singleton {
 			'capability' => '',
 		], $attributes, 'fyeo' );
 
+		// If dynamic is empty string, apply default (shortcode_atts doesn't replace empty strings).
+		if ( '' === $attributes['dynamic'] ) {
+			$attributes['dynamic'] = apply_filters( 'fyeo_default_render_style', '' );
+		}
 		// If capability is empty string, apply default (shortcode_atts doesn't replace empty strings).
 		if ( '' === $attributes['capability'] ) {
 			$attributes['capability'] = $this->capability->default_capability();

--- a/tests/test-parser.php
+++ b/tests/test-parser.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Class ParserTest
+ *
+ * @package For_Your_Eyes_Only
+ */
+
+/**
+ * Tests for Hametuha\ForYourEyesOnly\Parser::render().
+ */
+class ParserTest extends WP_UnitTestCase {
+
+	/**
+	 * @var \Hametuha\ForYourEyesOnly\Parser
+	 */
+	private $parser = null;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->parser = \Hametuha\ForYourEyesOnly\Parser::get_instance();
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'fyeo_default_render_style' );
+		parent::tearDown();
+	}
+
+	/**
+	 * block.json（v1.2.0以降）は "dynamic" 属性に静的な初期値 "" を持つため、
+	 * render_callback には常に $attributes['dynamic'] === '' が渡り得る。
+	 * shortcode_atts() はキーが既に存在する値を上書きしないため、
+	 * 'fyeo_default_render_style' フィルターで独自のデフォルトを設定しているサイトでは
+	 * そのフィルターが無視されてしまう不具合があった。
+	 */
+	public function test_dynamic_attribute_respects_filter_even_when_explicitly_empty() {
+		add_filter( 'fyeo_default_render_style', function () {
+			return 'dynamic';
+		} );
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		// block.json由来で dynamic 属性が明示的に空文字として渡ってくるケースを再現する。
+		$output = $this->parser->render(
+			[
+				'dynamic'    => '',
+				'capability' => 'read',
+			],
+			'secret content'
+		);
+
+		// 'dynamic' モードとして扱われ、権限があるユーザーには本文がそのまま返る。
+		$this->assertSame( 'secret content', $output );
+	}
+
+	/**
+	 * フィルターを登録していないサイトでは、従来通り非同期（Async）モードのままであることを確認する。
+	 */
+	public function test_dynamic_attribute_defaults_to_async_without_filter() {
+		$output = $this->parser->render(
+			[
+				'dynamic'    => '',
+				'capability' => 'read',
+			],
+			'secret content'
+		);
+
+		$this->assertStringContainsString( 'data-post-id', $output );
+	}
+}


### PR DESCRIPTION
## 背景

- #16 で `tag_line` と `capability` について同種の不具合が修正されたが、提案されていた `dynamic` への対策だけ実装から漏れていた

## 問題

- `block.json` の `dynamic` 属性の初期値は静的な `""`
- `Parser::render()` の `shortcode_atts()` はキーに値がある場合は上書きしないため、`dynamic` を明示保存していないブロック（＝ほとんどのケース）では `fyeo_default_render_style` フィルターが無視される
- 結果、PHPその場判定（Dynamic）ではなく非同期（JS + REST API）レンダリングにフォールバックする

## 影響

- `fyeo_default_render_style` フィルターでレンダリング方式を固定しているサイトが対象
- 非同期モード側のREST API認証（`is_user_logged_in()`）が想定と異なる認証方式のユーザーを判定できない場合、意図せずコンテンツが表示されなくなる

## 修正内容

`capability` / `tag_line` と同じパターンで、`shortcode_atts()` の後に空文字チェックを追加。

## テスト

- `tests/test-parser.php` を追加
  - フィルター登録時: `dynamic` が空文字でもフィルターの値が優先されることを確認
  - フィルター未登録時（標準利用）: 従来通り非同期モードのままであることを確認（回帰なし）
- `composer test` / `composer lint` 通過

## 関連

- https://tarosky.backlog.jp/view/CSLINFO_INSIDE-961

closes #16