### PR TITLE
Fix deploy: npm run build に修正（Missing script: package の解消）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install dependencies and build Assets
         run: |
           composer install --no-dev --prefer-dist
-          npm install
-          npm run package
+          npm ci --ignore-scripts
+          npm run build
 
       - name: Compile Translations
         run: composer i18n


### PR DESCRIPTION
## 問題

WordPress.org デプロイ（release published）が失敗していた。

```
npm error Missing script: "package"
```

Run: https://github.com/tarosky/for-your-eyes-only/actions/runs/30799395382

## 原因

`deploy.yml` は標準テンプレートの `npm run package` を実行していたが、本プラグインは `@wordpress/scripts` ベースで `package` スクリプトを持たず `build` のみ。CLAUDE.md のPlaygroundビルド表でも本プラグインは「composer + npm + **build**」に分類されている。

## 修正

- `npm run package` → `npm run build`（本プラグインが持つスクリプトに整合）
- `npm install` → `npm ci --ignore-scripts`（CLAUDE.md のCI標準に統一。husky prepare の起動も抑止）

## リリース再実行について

release イベントの再デプロイは、修正を master にマージした後、対象リリースを一度ドラフトに戻して再度 publish するとよい（ワークフロー定義はデフォルトブランチ側が使われ、コードはタグがチェックアウトされる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)